### PR TITLE
WCC Leaderboard Page: Remove Duplicate Nav Bar

### DIFF
--- a/pages/wcc/leaderboard/index.js
+++ b/pages/wcc/leaderboard/index.js
@@ -1,11 +1,8 @@
-import Head from 'next/head';
-import { Nav } from '../../../components/landingPage/Nav/nav';
 import Leaderboard from '../../../components/Leaderboard';
 import { readFile } from 'fs/promises';
 
 export default function RochesterLeaderboard({ AOC, form }) {
     return <>
-        <Nav />
         <Leaderboard {...{ AOC, form, location: 'Minnesota' }} />
     </>;
 }


### PR DESCRIPTION
The `WCC Leaderboard` page had two navigation bars displayed. That extra one has been removed. 