### PR TITLE
Fixed ordering of combined leaderboard - Recalculated local scores

### DIFF
--- a/components/Leaderboard/index.js
+++ b/components/Leaderboard/index.js
@@ -63,32 +63,51 @@ export default function Leaderboard({ AOC, form, location }) {
         // The first user to get each star gets N points
         // the seconds gets N-1, and so on
 
-        const N = users.length
+        const N = users.length;
         let current_puzzles = new Set();
-        users.forEach(u => Object.keys(u.completion_day_level).forEach(k => current_puzzles.add(k)));
+        users.forEach((u) =>
+            Object.keys(u.completion_day_level).forEach((k) => current_puzzles.add(k))
+        );
 
-        let new_localscores = new Map()
+        let new_localscores = new Map();
 
         // For every star, make a list of the users that completed it in order
         let puzzle_completers_ordered = [...current_puzzles]
-            .map(puzzle_id => [[puzzle_id, 1], [puzzle_id, 2]])
+            .map((puzzle_id) => [
+                [puzzle_id, 1],
+                [puzzle_id, 2],
+            ])
             .flat()
-            .map(([puzzle, star]) => users
-                .filter(u => puzzle in u.completion_day_level && star in u.completion_day_level[puzzle])
-                .sort((a, b) => a.completion_day_level[puzzle][star].get_star_ts - b.completion_day_level[puzzle][star].get_star_ts)
-                .map(u => u.name)
+            .map(([puzzle, star]) =>
+                users
+                    .filter(
+                        (u) =>
+                            puzzle in u.completion_day_level &&
+                            star in u.completion_day_level[puzzle]
+                    )
+                    .sort(
+                        (a, b) =>
+                            a.completion_day_level[puzzle][star].get_star_ts -
+                            b.completion_day_level[puzzle][star].get_star_ts
+                    )
+                    .map((u) => u.name)
             );
 
-        puzzle_completers_ordered.forEach(star_catchers =>
+        puzzle_completers_ordered.forEach((star_catchers) =>
             star_catchers.forEach((name, index) => {
-                new_localscores.set(name, new_localscores.has(name) ? new_localscores.get(name) + N - index : N - index)
+                new_localscores.set(
+                    name,
+                    new_localscores.has(name) ? new_localscores.get(name) + N - index : N - index
+                );
             })
-        )
+        );
 
-        console.log(new_localscores)
-        console.log(users)
+        console.log(new_localscores);
+        console.log(users);
 
-        return users.map(u => (new_localscores.has(u.name)) ? { ...u, local_score: new_localscores.get(u.name) } : u)
+        return users.map((u) =>
+            new_localscores.has(u.name) ? { ...u, local_score: new_localscores.get(u.name) } : u
+        );
     }
 
     /*
@@ -171,6 +190,7 @@ export default function Leaderboard({ AOC, form, location }) {
                                         getSchoolColor,
                                         isUserValid,
                                         calculateTeamStars,
+                                        regenLocalScores,
                                     }}
                                 />
                             </tbody>
@@ -182,7 +202,9 @@ export default function Leaderboard({ AOC, form, location }) {
                     <div className={styles.scrollTable}>
                         <table>
                             <tbody>
-                                <IndividualLeaderboard {...{ AOC, form, generateStars, isUserValid, regenLocalScores }} />
+                                <IndividualLeaderboard
+                                    {...{ AOC, form, generateStars, isUserValid, regenLocalScores }}
+                                />
                             </tbody>
                         </table>
                     </div>

--- a/components/Leaderboard/index.js
+++ b/components/Leaderboard/index.js
@@ -54,6 +54,44 @@ export default function Leaderboard({ AOC, form, location }) {
     }
 
     /*
+    Regenerate the local score for each user in a combined leaderboard in the same way that the Advent of Code leaderboard does
+    */
+
+    function regenLocalScores(users) {
+        // THE CALCULATION:
+        // For N users
+        // The first user to get each star gets N points
+        // the seconds gets N-1, and so on
+
+        const N = users.length
+        let current_puzzles = new Set();
+        users.forEach(u => Object.keys(u.completion_day_level).forEach(k => current_puzzles.add(k)));
+
+        let new_localscores = new Map()
+
+        // For every star, make a list of the users that completed it in order
+        let puzzle_completers_ordered = [...current_puzzles]
+            .map(puzzle_id => [[puzzle_id, 1], [puzzle_id, 2]])
+            .flat()
+            .map(([puzzle, star]) => users
+                .filter(u => puzzle in u.completion_day_level && star in u.completion_day_level[puzzle])
+                .sort((a, b) => a.completion_day_level[puzzle][star].get_star_ts - b.completion_day_level[puzzle][star].get_star_ts)
+                .map(u => u.name)
+            );
+
+        puzzle_completers_ordered.forEach(star_catchers =>
+            star_catchers.forEach((name, index) => {
+                new_localscores.set(name, new_localscores.has(name) ? new_localscores.get(name) + N - index : N - index)
+            })
+        )
+
+        console.log(new_localscores)
+        console.log(users)
+
+        return users.map(u => (new_localscores.has(u.name)) ? { ...u, local_score: new_localscores.get(u.name) } : u)
+    }
+
+    /*
     calculate team's total stars completed
     */
 
@@ -138,7 +176,7 @@ export default function Leaderboard({ AOC, form, location }) {
                     <div className={styles.table}>
                         <table>
                             <tbody>
-                                <IndividualLeaderboard {...{ AOC, form, generateStars, isUserValid }} />
+                                <IndividualLeaderboard {...{ AOC, form, generateStars, isUserValid, regenLocalScores }} />
                             </tbody>
                         </table>
                     </div>

--- a/components/Leaderboard/individuals/index.js
+++ b/components/Leaderboard/individuals/index.js
@@ -2,9 +2,10 @@ import coloredStyles from '../schoolColors.module.scss';
 import lbStyles from '../leaderboard.module.scss';
 import styles from '../styles.module.scss';
 
-export default function IndividualLeaderboard({ AOC, form, generateStars, isUserValid }) {
+export default function IndividualLeaderboard({ AOC, form, generateStars, isUserValid, regenLocalScores }) {
     let tableRows = []; //array of table rows with info
     let aocMembers = Object.values(AOC); //Convert AOC.members obj into array
+    aocMembers = regenLocalScores(aocMembers)
     aocMembers.sort((a, b) => b.stars - a.stars || b.local_score - a.local_score); //sort by stars & score
     for (let AOCUser of aocMembers) {
         if (!isUserValid(AOCUser)) continue;

--- a/components/Leaderboard/teams/index.js
+++ b/components/Leaderboard/teams/index.js
@@ -4,7 +4,7 @@
 
 */
 import lbStyles from '../leaderboard.module.scss';
-import styles from "../styles.module.scss";
+import styles from '../styles.module.scss';
 
 function hexToRGB(hex) {
     let aRgbHex = hex.match(/.{1,2}/g);
@@ -36,6 +36,7 @@ export default function TeamLeaderboard({
     let tableRows = []; //array of table row elements
     let teams = {}; // obj teamName: array members
     let aocMembers = Object.values(AOC); //convert AOC.members to a obj
+    aocMembers = regenLocalScores(aocMembers);
     aocMembers.sort((a, b) => b.stars - a.stars || b.local_score - a.local_score); //sort by stars & score
     for (let AOCUser of aocMembers) {
         if (!isUserValid(AOCUser)) continue;
@@ -94,7 +95,15 @@ export default function TeamLeaderboard({
                 <td>
                     <p>{score} </p>
                 </td>
-                <td className={styles.mobile + " " + (stars % 2 == 0 ? lbStyles.goldStars : lbStyles.silverStar)}>{stars}★ </td>
+                <td
+                    className={
+                        styles.mobile +
+                        ' ' +
+                        (stars % 2 == 0 ? lbStyles.goldStars : lbStyles.silverStar)
+                    }
+                >
+                    {stars}★{' '}
+                </td>
                 <td className={styles.hide}>{generateStars(stars)}</td>
                 <td>
                     <p

--- a/components/Leaderboard/teams/index.js
+++ b/components/Leaderboard/teams/index.js
@@ -32,6 +32,7 @@ export default function TeamLeaderboard({
     getSchoolColor,
     isUserValid,
     calculateTeamStars,
+    regenLocalScores
 }) {
     let tableRows = []; //array of table row elements
     let teams = {}; // obj teamName: array members


### PR DESCRIPTION
Pretty much just adds one thing: `regenLocalScores`
Recalculates the local score for each user in a larger combined individual leaderboard so the ordering is correct by using the same formula that the AOC official leaderboard does:
> For N users
> The first user to get each star gets N points
> the second gets N-1, and so on

**tl;dr**: Arbitrarily large leaderboards created from combining multiple official leaderboards are now correctly scored and ordered