### PR TITLE
Add Countdowns to Leaderboards

### DIFF
--- a/components/Countdown/countdown.js
+++ b/components/Countdown/countdown.js
@@ -4,21 +4,21 @@ import { intervalToDuration, isWithinInterval, startOfTomorrow } from 'date-fns'
 import styles from './countdown.module.scss';
 
 const defaultRemainingTime = {
-  years: 0,
-  months: 0,
-  days: 0,
-  hours: 0,
-  minutes: 0,
-  seconds: 0
+  years: -1,
+  months: -1,
+  days: -1,
+  hours: -1,
+  minutes: -1,
+  seconds: -1
 }
 
 const suffixesForCountdown = {
-  years: 'year(s)',
-  months: 'month(s)',
-  days: 'day(s)',
-  hours: 'hour(s)',
-  minutes: 'minute(s)',
-  seconds: 'second(s)'
+  years: 'y(s)',
+  months: 'm(s)',
+  days: 'd(s)',
+  hours: 'h(s)',
+  minutes: 'm(s)',
+  seconds: 's(s)'
 }
 
 const timeBetweenDates = (startDate, endDate, options) => {
@@ -61,7 +61,7 @@ const Countdown = (props) => {
       {
         countdownIsValid(props.startDate || new Date(), props.repeatUntil || props.endDate || new Date()) ?
           Object.keys(timeLeft).map(key => (
-            timeLeft[key] !== 0 ? 
+            timeLeft[key] !== -1 && (timeLeft[key] !== 0 || key == 'seconds')? 
               <>
                 <span>{timeLeft[key]}</span> <span>{suffixesForCountdown[key]}</span>{key !== 'seconds' ? <span>{props.dateSeparator || ', '}</span> : <span></span> }
               </>

--- a/components/Countdown/countdown.js
+++ b/components/Countdown/countdown.js
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import { intervalToDuration, isWithinInterval, startOfTomorrow } from 'date-fns'
+
+import styles from './countdown.module.scss';
+
+const defaultRemainingTime = {
+  years: 0,
+  months: 0,
+  days: 0,
+  hours: 0,
+  minutes: 0,
+  seconds: 0
+}
+
+const suffixesForCountdown = {
+  years: 'year(s)',
+  months: 'month(s)',
+  days: 'day(s)',
+  hours: 'hour(s)',
+  minutes: 'minute(s)',
+  seconds: 'second(s)'
+}
+
+const timeBetweenDates = (startDate, endDate, options) => {
+  if (!startDate) { startDate = new Date(); }
+  if (!endDate) { endDate = new Date(); }
+  if (!options) { options = {} }
+
+  try {
+    return(intervalToDuration({start: startDate, end:endDate}));
+  } catch {
+    return defaultRemainingTime;
+  }
+}
+
+const countdownIsValid = (startDate, endDate) => {
+  try {
+    return isWithinInterval(new Date(), {start: startDate || new Date(), end: endDate || new Date()});
+  } catch {
+    return false;
+  }
+}
+
+const Countdown = (props) => {
+
+  const [timeLeft, setTimeLeft] = useState(defaultRemainingTime);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setTimeLeft(timeBetweenDates(props.startDate || new Date(), props.endDate || startOfTomorrow(), props.dateOptions));
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  });
+
+  return (
+    <div className={styles.countdownWrapper}>
+      <span className={styles.countdownPrefix}>{props.prefix || "Countdown"}</span>
+      <span>{props.divider || ': '}</span> 
+
+      {
+        countdownIsValid(props.startDate || new Date(), props.repeatUntil || props.endDate || new Date()) ?
+          Object.keys(timeLeft).map(key => (
+            timeLeft[key] !== 0 ? 
+              <>
+                <span>{timeLeft[key]}</span> <span>{suffixesForCountdown[key]}</span>{key !== 'seconds' ? <span>{props.dateSeparator || ', '}</span> : <span></span> }
+              </>
+              :
+              <></>
+          ))
+        :
+          <>
+            <span>{props.endMessage || 'The countdown has ended.' }</span>
+          </>
+      }
+
+    </div>
+  );
+}
+
+export default Countdown;

--- a/components/Countdown/countdown.module.scss
+++ b/components/Countdown/countdown.module.scss
@@ -1,5 +1,6 @@
 .countdownWrapper {
   padding: 0.25rem;
+  padding-left: 0;
 }
 
 div .countdownPrefix {

--- a/components/Countdown/countdown.module.scss
+++ b/components/Countdown/countdown.module.scss
@@ -1,0 +1,7 @@
+.countdownWrapper {
+  padding: 1rem;
+}
+
+div .countdownPrefix {
+  font-weight: bold;
+}

--- a/components/Countdown/countdown.module.scss
+++ b/components/Countdown/countdown.module.scss
@@ -1,5 +1,5 @@
 .countdownWrapper {
-  padding: 1rem;
+  padding: 0.25rem;
 }
 
 div .countdownPrefix {

--- a/components/Leaderboard/index.js
+++ b/components/Leaderboard/index.js
@@ -4,6 +4,9 @@ import IndividualLeaderboard from './individuals';
 import TeamLeaderboard from './teams';
 import SchoolLeaderboard from './schools';
 import { Nav } from '../landingPage/Nav/nav';
+import Countdown from '../Countdown/countdown';
+
+import { addSeconds, fromUnixTime, startOfTomorrow } from 'date-fns';
 
 const MAX_STARS = 25;
 const STAR = '★';
@@ -95,6 +98,11 @@ export default function Leaderboard({ AOC, form, location }) {
             </Head>
 
             <Nav />
+
+            <div className={styles.countdownRowWrapper}>
+                <div><Countdown prefix='Next Puzzle Unlocks In' endDate={addSeconds(startOfTomorrow(), 1)} repeatUntil={fromUnixTime(1671926400)} endMessage='Advent of Code 2022 has ended.' /></div>
+                <div><Countdown prefix='Competition Ends In' endDate={fromUnixTime(1672552800)} endMessage='The competition has ended.'/></div>
+            </div>
 
             <div className={styles.leaderboard}>
                 <h1 onClick={titleEasterEgg}>{location} Leaderboard</h1>

--- a/components/Leaderboard/index.js
+++ b/components/Leaderboard/index.js
@@ -99,16 +99,17 @@ export default function Leaderboard({ AOC, form, location }) {
 
             <Nav />
 
-            <div className={styles.countdownRowWrapper}>
-                <div><Countdown prefix='Next Puzzle Unlocks In' endDate={addSeconds(startOfTomorrow(), 1)} repeatUntil={fromUnixTime(1671926400)} endMessage='Advent of Code 2022 has ended.' /></div>
-                <div><Countdown prefix='Competition Ends In' endDate={fromUnixTime(1672552800)} endMessage='The competition has ended.'/></div>
-            </div>
+
 
             <div className={styles.leaderboard}>
                 <h1 onClick={titleEasterEgg}>{location} Leaderboard</h1>
                 <div className={styles.section}>
                     <h2>Statistics</h2>
                     <div></div>
+                    <div className={styles.countdownRowWrapper}>
+                        <div><Countdown prefix='Next Puzzle Unlocks In' endDate={addSeconds(startOfTomorrow(), 1)} repeatUntil={fromUnixTime(1671926400)} endMessage='Advent of Code 2022 has ended.' /></div>
+                        <div><Countdown prefix='Competition Ends In' endDate={fromUnixTime(1672552801)} endMessage='The competition has ended.'/></div>
+                    </div>
                 </div>
                 <div className={styles.section}>
                     <h2>Schools</h2>

--- a/components/Leaderboard/index.js
+++ b/components/Leaderboard/index.js
@@ -99,16 +99,27 @@ export default function Leaderboard({ AOC, form, location }) {
 
             <Nav />
 
-
-
             <div className={styles.leaderboard}>
                 <h1 onClick={titleEasterEgg}>{location} Leaderboard</h1>
                 <div className={styles.section}>
                     <h2>Statistics</h2>
                     <div></div>
-                    <div className={styles.countdownRowWrapper}>
-                        <div><Countdown prefix='Next Puzzle Unlocks In' endDate={addSeconds(startOfTomorrow(), 1)} repeatUntil={fromUnixTime(1671926400)} endMessage='Advent of Code 2022 has ended.' /></div>
-                        <div><Countdown prefix='Competition Ends In' endDate={fromUnixTime(1672552801)} endMessage='The competition has ended.'/></div>
+                    <div className={styles.countdownRowWrapper} style={{ textAlign: 'start' }}>
+                        <div>
+                            <Countdown
+                                prefix="Next Puzzle Unlocks In"
+                                endDate={addSeconds(startOfTomorrow(), 1)}
+                                repeatUntil={fromUnixTime(1671926400)}
+                                endMessage="Advent of Code 2022 has ended."
+                            />
+                        </div>
+                        <div>
+                            <Countdown
+                                prefix="Competition Ends In"
+                                endDate={fromUnixTime(1672552801)}
+                                endMessage="The competition has ended."
+                            />
+                        </div>
                     </div>
                 </div>
                 <div className={styles.section}>

--- a/components/Leaderboard/leaderboard.module.scss
+++ b/components/Leaderboard/leaderboard.module.scss
@@ -21,6 +21,19 @@
             font-weight: bolder;
             margin: 8px 0;
         }
+
+        .countdownRowWrapper {
+            white-space: normal !important;
+        
+            div {
+                @media screen and (max-width: 600px) {
+                    .countdownWrapper {
+                        max-width: 16rem;
+                    }
+                }
+            }
+        }
+
         .stars {
             text-align: center;
             display: flex;
@@ -55,14 +68,5 @@
         overflow: auto;
         width: 95vw;
         position: relative;
-    }
-}
-
-.countdownRowWrapper {
-    display: flex;
-    justify-content: space-between;
-
-    div {
-        max-width: 24rem;
     }
 }

--- a/components/Leaderboard/leaderboard.module.scss
+++ b/components/Leaderboard/leaderboard.module.scss
@@ -57,6 +57,7 @@
         position: relative;
     }
 }
+
 .countdownRowWrapper {
     display: flex;
     justify-content: space-between;

--- a/components/Leaderboard/leaderboard.module.scss
+++ b/components/Leaderboard/leaderboard.module.scss
@@ -58,3 +58,12 @@
     color: transparent;
     user-select: none;
 }
+
+.countdownRowWrapper {
+    display: flex;
+    justify-content: space-between;
+
+    div {
+        max-width: 24rem;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mmc-website",
       "version": "0.1.0",
       "dependencies": {
+        "date-fns": "^2.29.3",
         "eslint": "8.28.0",
         "eslint-config-next": "13.0.4",
         "express": "^4.18.2",
@@ -907,6 +908,18 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4238,6 +4251,11 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
+    },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "date-fns": "^2.29.3",
     "eslint": "8.28.0",
     "eslint-config-next": "13.0.4",
     "express": "^4.18.2",


### PR DESCRIPTION
This PR addresses #19:

- This PR adds a new `Countdown` component. 
- The `date-fns` library was added for convince for date manipulation.
- 2 countdowns have been added to the Leaderboard component to display (1) a countdown to the next puzzle unlocking and (2) a countdown to the end of our competition on New Year's Eve at midnight.