### PR TITLE
Hopefully fix issue of no google token refreshing

### DIFF
--- a/python/sheet_to_json.py
+++ b/python/sheet_to_json.py
@@ -79,23 +79,22 @@ def main():
         
     # User login to generate tokens
     # if not creds or not creds.valid:
-    #     if creds and creds.expired and creds.refresh_token:
-    #         creds.refresh(Request())
-    #     else:
-    #         flow = InstalledAppFlow.from_client_secrets_file(
-    #             'credentials.json', SCOPES)
-    #         creds = flow.run_local_server(port=0)
+    #     flow = InstalledAppFlow.from_client_secrets_file(
+    #         'credentials.json', SCOPES)
+    #     creds = flow.run_local_server(port=0)
     #     # Save the credentials for the next run
     #     with open(TOKENPATH, 'w') as token:
     #         token.write(creds.to_json())
     
-    if not creds or not creds.valid:
+    if not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
             print("Error, token irrepairable")
             exit(1)
-
+        with open(TOKENPATH, 'w') as token:
+            token.write(creds.to_json())
+    
     ######### API CALLS
     service = build('sheets', 'v4', credentials=creds)
     


### PR DESCRIPTION
Every so often the google token on the server seems to expire (which should be noticeable form the cron output) but otherwise causes people to be missing from the leaderboard. I'm not entirely sure that this fixes that issue (I have no way of testing it without waiting a few days for my token to expire) but I am sure that this does not break the `sheet_to_json.py` script (as least on my machine) and there is a good chance that this might fix it. Otherwise, I'll just keep manually refreshing the token which is a nuisance.